### PR TITLE
Use Set Literals Instead of Sets from Lists

### DIFF
--- a/train_evaluate_model.py
+++ b/train_evaluate_model.py
@@ -250,13 +250,13 @@ if __name__ == '__main__':
 
         # add log based features
         # first cost
-        for col in (set(price_features) - set(['cost'])):
+        for col in (set(price_features) - {'cost'}):
             train[str(col) + '_cost_log'] = np.log((train[col] + 10.)/(train['cost'] + 10.))
             test[str(col) + '_cost_log'] = np.log((test[col] + 10.)/(test['cost'] + 10.))
             new_col_types.append('log_new_cost_transformed')
 
         # now price
-        for col in (set(price_features) - set(['cost', 'price'])):
+        for col in (set(price_features) - {'cost', 'price'}):
             train[str(col) + '_price_log'] = np.log((train[col] + 10.)/(train['price'] + 10.))
             test[str(col) + '_price_log'] = np.log((test[col] + 10.)/(test['price'] + 10.))
             new_col_types.append('log_new_price_transformed')


### PR DESCRIPTION
This codemod converts Python set constructions using literal list arguments into more efficient and readable set literals. It simplifies expressions like `set([1, 2, 3])` to `{1, 2, 3}`, enhancing both performance and code clarity.

Our changes look like this:
```diff
-x = set([1, 2, 3])
+x = {1, 2, 3}
```


I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/use-set-literal](https://docs.pixee.ai/codemods/python/pixee_python_use-set-literal)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Fanomaly-detection-walmart%7Cc28a8440b10f4423d3f6f3d79f2c433fde41a2c7)

<!--{"type":"DRIP","codemod":"pixee:python/use-set-literal"}-->